### PR TITLE
remove opens and use file handles

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Tests for ppx_deriving_yaml
+name: Tests for obuilderfs
 on: [push, pull_request]
 jobs:
   test:

--- a/src/obuilderfs.c
+++ b/src/obuilderfs.c
@@ -853,17 +853,11 @@ static int xmp_read(const char *path, char *buf, size_t size, off_t offset,
 										struct fuse_file_info *fi)
 {
 	int res;
-
-	char *new_path = process_path(path);
-	int fd = open(new_path, fi->flags);
-	// File handle okay?
-	res = pread(fd, buf, size, offset);
+	res = pread(fi->fh, buf, size, offset);
 	if (res == -1)
+	{
 		res = -errno;
-
-	close(fd);
-	free(new_path);
-
+	}
 	return res;
 }
 
@@ -893,19 +887,11 @@ static int xmp_write(const char *path, const char *buf, size_t size,
 										 off_t offset, struct fuse_file_info *fi)
 {
 	int res;
-
-	char *new_path = process_path(path);
-	int fd = open(new_path, fi->flags);
-
-	res = pwrite(fd, buf, size, offset);
+	res = pwrite(fi->fh, buf, size, offset);
 	if (res == -1)
 	{
+		res = -errno;
 	}
-	res = -errno;
-
-	close(fd);
-	free(new_path);
-
 	return res;
 }
 


### PR DESCRIPTION
Whilst building a template user (installing `homebrew`, `opam 2.0.7` and `opam 2.1.0`) the whole thing would fail because of too many open file descriptors. I believe this is due to the read and write methods reopening the path, but we can reuse the file handler from the file information struct (`fi->fh`) which has already been processed by `create` or `open` I believe. 