### PR TITLE
Updated to installation path to use `brew --prefix`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
+homebrew := $(shell brew --prefix)
+
 all:
 	$(MAKE) -C src 
 
 install:
-	cp ./install/obuilderfs /usr/local/bin/obuilderfs
+	cp ./install/obuilderfs $(homebrew)/bin/obuilderfs
 
 clean: 
 	$(MAKE) -C src clean


### PR DESCRIPTION
The `Makefile` assumes that `/usr/local/bin` exists which is not the case when installing on Apple M1.  Therefore install to `brew --prefix` which returns either `/usr/local` or `/opt/homebrew` for Intel and M1 respectively.